### PR TITLE
Created adapter for timedelta and added tests related to new adapter

### DIFF
--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -11,6 +11,7 @@ import pytz
 import time
 from base64 import b64encode
 from decimal import Decimal
+from datetime import timedelta
 
 
 def datetime_adapter(obj, request):
@@ -78,31 +79,20 @@ def timedelta_adapter(obj, request, mode='seconds'):
     :rtype: str, seconds corresponding to timedelta
     """
 
-    seconds = obj.total_seconds()
-
     if mode == 'microseconds':
-        # 1 second = 10**6 microseconds
-        return seconds * 10**6
+        return obj / timedelta(microseconds=1)
     elif mode == 'milliseconds':
-        # 1 second = 10**3 milliseconds
-        return seconds * 10**3
+        return obj / timedelta(milliseconds=1)
     elif mode == 'seconds':
-        return seconds
+        return obj.total_seconds()
     elif mode == 'minutes':
-        # 1 minute = 60 seconds
-        return seconds / 60
+        return obj / timedelta(minutes=1)
     elif mode == 'hours':
-        # 1 hour = 60 minutes
-        # 3600 = 60 * 60
-        return seconds / 3600
+        return obj / timedelta(hours=1)
     elif mode == 'days':
-        # 1 day = 24 hours
-        # 86400 = 60 * 60 * 24
-        return seconds / 86400
+        return obj / timedelta(days=1)
     elif mode == 'weeks':
-        # 1 week = 7 days
-        # 604800 = 60 * 60 * 24 * 7
-        return seconds / 604800
+        return obj / timedelta(weeks=1)
     else:
         raise ValueError(
             ("Provided mode for timedelta_adapter is not valid. Found '%s'"

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -102,8 +102,6 @@ def timedelta_adapter_factory(mode=TimeDeltaModes.SECONDS):
         :rtype: str, seconds corresponding to timedelta
         """
 
-        import ipdb; ipdb.set_trace()
-
         if mode == TimeDeltaModes.MICROSECONDS:
             return obj / timedelta(microseconds=1)
         elif mode == TimeDeltaModes.MILLISECONDS:

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -13,7 +13,7 @@ from base64 import b64encode
 from decimal import Decimal
 from datetime import timedelta
 
-from enum import Enum, auto, unique
+from enum import Enum, unique
 
 
 def datetime_adapter(obj, request):
@@ -48,13 +48,13 @@ class TimeDeltaModes(Enum):
     """This enum is aimed at creating constants for setting the serialization
        mode for timedelta adapter."""
 
-    MICROSECONDS = auto()
-    MILLISECONDS = auto()
-    SECONDS = auto()
-    MINUTES = auto()
-    HOURS = auto()
-    DAYS = auto()
-    WEEKS = auto()
+    MICROSECONDS = 1
+    MILLISECONDS = 2
+    SECONDS = 3
+    MINUTES = 4
+    HOURS = 5
+    DAYS = 6
+    WEEKS = 7
 
 
 def timedelta_adapter_factory(mode=TimeDeltaModes.SECONDS):

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -104,10 +104,10 @@ def timedelta_adapter(obj, request, mode='seconds'):
         return seconds / 604800
     else:
         raise ValueError(
-                ("Provided mode for timedelta_adapter is not valid. Found '%s'"
-                 "." % mode
-                 )
-                )
+            ("Provided mode for timedelta_adapter is not valid. Found '%s'"
+             "." % mode
+             )
+            )
 
     return obj.total_seconds()
 

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -38,6 +38,24 @@ def datetime_adapter(obj, request):
     return obj.isoformat()
 
 
+def timedelta_adapter(obj, request):
+
+    """Format the fields.TimeDelta to return String
+
+    ::
+        from pyramid.renderers import JSON
+        from datetime import timedelta
+        json_renderer = JSON()
+        json_renderer.add_adapter(timedelta, timedelta_adapter)
+        config.add_renderer('json', json_renderer)
+
+    :param obj: timedelta obj
+    :rtype: str, seconds corresponding to timedelta
+    """
+
+    return obj.total_seconds()
+
+
 def date_adapter(obj, request):
     """Format the fields.Date to return String
 

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -2,6 +2,7 @@
 #
 #    Copyright (C) 2017 Franck BRET <franckbret@gmail.com>
 #    Copyright (C) 2017 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#    Copyright (C) 2019 Alexis TOURNEUX <tourneuxalexis@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -38,7 +38,7 @@ def datetime_adapter(obj, request):
     return obj.isoformat()
 
 
-def timedelta_adapter(obj, request):
+def timedelta_adapter(obj, request, mode='seconds'):
 
     """Format the fields.TimeDelta to return String
 
@@ -49,9 +49,65 @@ def timedelta_adapter(obj, request):
         json_renderer.add_adapter(timedelta, timedelta_adapter)
         config.add_renderer('json', json_renderer)
 
+    The mode parameter can be used to set the output of the adpater.
+    This parameter can either be :
+
+        * microseconds
+        * milliseconds
+        * seconds (default)
+        * minutes
+        * hours
+        * days
+        * weeks
+
+    When using this adapter with non default parameter, it might be used the
+    following way :
+
+    ::
+        from pyramid.renderers import JSON
+        from datetime import timedelta
+        json_renderer = JSON()
+        json_renderer.add_adapter(
+            timedelta, lambda obj, request: timedelta_adapter(
+                obj, request, 'hours'))
+        config.add_renderer('json', json_renderer)
+
     :param obj: timedelta obj
+    :param mode: str
     :rtype: str, seconds corresponding to timedelta
     """
+
+    seconds = obj.total_seconds()
+
+    if mode == 'microseconds':
+        # 1 second = 10**6 microseconds
+        return seconds * 10**6
+    elif mode == 'milliseconds':
+        # 1 second = 10**3 milliseconds
+        return seconds * 10**3
+    elif mode == 'seconds':
+        return seconds
+    elif mode == 'minutes':
+        # 1 minute = 60 seconds
+        return seconds / 60
+    elif mode == 'hours':
+        # 1 hour = 60 minutes
+        # 3600 = 60 * 60
+        return seconds / 3600
+    elif mode == 'days':
+        # 1 day = 24 hours
+        # 86400 = 60 * 60 * 24
+        return seconds / 86400
+    elif mode == 'weeks':
+        # 1 week = 7 days
+        # 604800 = 60 * 60 * 24 * 7
+        return seconds / 604800
+    else:
+        raise ValueError(
+                ("Provided mode for timedelta_adapter is not valid. Found '%s'"
+                 "." % mode
+                 )
+                )
 
     return obj.total_seconds()
 

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -13,6 +13,8 @@ from base64 import b64encode
 from decimal import Decimal
 from datetime import timedelta
 
+from enum import Enum, auto, unique
+
 
 def datetime_adapter(obj, request):
     """Format the fields.DateTime to return String
@@ -40,65 +42,88 @@ def datetime_adapter(obj, request):
     return obj.isoformat()
 
 
-def timedelta_adapter(obj, request, mode='seconds'):
+@unique
+class TimeDeltaModes(Enum):
 
-    """Format the fields.TimeDelta to return String
+    """This enum is aimed at creating constants for setting the serialization
+       mode for timedelta adapter."""
 
-    ::
-        from pyramid.renderers import JSON
-        from datetime import timedelta
-        json_renderer = JSON()
-        json_renderer.add_adapter(timedelta, timedelta_adapter)
-        config.add_renderer('json', json_renderer)
+    MICROSECONDS = auto()
+    MILLISECONDS = auto()
+    SECONDS = auto()
+    MINUTES = auto()
+    HOURS = auto()
+    DAYS = auto()
+    WEEKS = auto()
 
-    The mode parameter can be used to set the output of the adpater.
-    This parameter can either be :
 
-        * microseconds
-        * milliseconds
-        * seconds (default)
-        * minutes
-        * hours
-        * days
-        * weeks
+def timedelta_adapter_factory(mode=TimeDeltaModes.SECONDS):
+    def timedelta_adapter(obj, request):
 
-    When using this adapter with non default parameter, it might be used the
-    following way :
+        """Format the fields.TimeDelta to return String
 
-    ::
-        from pyramid.renderers import JSON
-        from datetime import timedelta
-        json_renderer = JSON()
-        json_renderer.add_adapter(
-            timedelta, lambda obj, request: timedelta_adapter(
-                obj, request, 'hours'))
-        config.add_renderer('json', json_renderer)
+        ::
+            from pyramid.renderers import JSON
+            from datetime import timedelta
+            from anyblok_pyramid.adapter import timedelta_adapter_factory
+            json_renderer = JSON()
+            json_renderer.add_adapter(timedelta, timedelta_adapter_factory())
+            config.add_renderer('json', json_renderer)
 
-    :param obj: timedelta obj
-    :param mode: str
-    :rtype: str, seconds corresponding to timedelta
-    """
+        The mode parameter can be used to set the output of the adapter.
+        This parameter can either be :
 
-    if mode == 'microseconds':
-        return obj / timedelta(microseconds=1)
-    elif mode == 'milliseconds':
-        return obj / timedelta(milliseconds=1)
-    elif mode == 'seconds':
-        return obj.total_seconds()
-    elif mode == 'minutes':
-        return obj / timedelta(minutes=1)
-    elif mode == 'hours':
-        return obj / timedelta(hours=1)
-    elif mode == 'days':
-        return obj / timedelta(days=1)
-    elif mode == 'weeks':
-        return obj / timedelta(weeks=1)
-    else:
-        raise ValueError(
-            ("Provided mode for timedelta_adapter is not valid. Found '%s'"
-             "." % mode))
+            * microseconds -> TimeDeltaModes.MICROSECONDS
+            * milliseconds -> TimeDeltaModes.MILLISECONDS
+            * seconds (default) -> TimeDeltaModes.SECONDS
+            * minutes -> TimeDeltaModes.MINUTES
+            * hours -> TimeDeltaModes.HOURS
+            * days -> TimeDeltaModes.DAYS
+            * weeks -> TimeDeltaModes.WEEKS
 
-    return obj.total_seconds()
+        When using this adapter with non default parameter, it might be used the
+        following way :
+
+        ::
+            from pyramid.renderers import JSON
+            from datetime import timedelta
+            from anyblok_pyramid.adapter import (
+                timedelta_adapter_factory,
+                TimeDeltaModes
+            )
+
+            json_renderer = JSON()
+            json_renderer.add_adapter(
+                timedelta, timedelta_adapter_factory(TimeDeltaModes.HOURS))
+            config.add_renderer('json', json_renderer)
+
+        :param obj: timedelta obj
+        :param mode: str
+        :rtype: str, seconds corresponding to timedelta
+        """
+
+        import ipdb; ipdb.set_trace()
+
+        if mode == TimeDeltaModes.MICROSECONDS:
+            return obj / timedelta(microseconds=1)
+        elif mode == TimeDeltaModes.MILLISECONDS:
+            return obj / timedelta(milliseconds=1)
+        elif mode == TimeDeltaModes.SECONDS:
+            return obj.total_seconds()
+        elif mode == TimeDeltaModes.MINUTES:
+            return obj / timedelta(minutes=1)
+        elif mode == TimeDeltaModes.HOURS:
+            return obj / timedelta(hours=1)
+        elif mode == TimeDeltaModes.DAYS:
+            return obj / timedelta(days=1)
+        elif mode == TimeDeltaModes.WEEKS:
+            return obj / timedelta(weeks=1)
+        else:
+            raise ValueError(
+                ("Provided mode for timedelta_adapter is not valid. Found '%s'"
+                 "." % mode))
+
+    return timedelta_adapter
 
 
 def date_adapter(obj, request):

--- a/anyblok_pyramid/adapter.py
+++ b/anyblok_pyramid/adapter.py
@@ -105,9 +105,7 @@ def timedelta_adapter(obj, request, mode='seconds'):
     else:
         raise ValueError(
             ("Provided mode for timedelta_adapter is not valid. Found '%s'"
-             "." % mode
-             )
-            )
+             "." % mode))
 
     return obj.total_seconds()
 

--- a/anyblok_pyramid/tests/test_adapter.py
+++ b/anyblok_pyramid/tests/test_adapter.py
@@ -11,13 +11,13 @@ from uuid import UUID, uuid1
 from os import urandom
 from decimal import Decimal
 from anyblok_pyramid.adapter import (
-        datetime_adapter,
-        date_adapter,
-        timedelta_adapter,
-        uuid_adapter,
-        bytes_adapter,
-        decimal_adapter,
-        )
+    datetime_adapter,
+    date_adapter,
+    timedelta_adapter,
+    uuid_adapter,
+    bytes_adapter,
+    decimal_adapter,
+)
 from anyblok_pyramid.testing import init_web_server
 
 
@@ -38,7 +38,7 @@ class TestAdapter:
         webserver = init_web_server(add_route_and_views)
         res = webserver.get('/test/', status=200)
         assert res.json_body['datetime'] == datetime_adapter(
-                datetime(2017, 10, 1, 1, 1, 1), None)
+            datetime(2017, 10, 1, 1, 1, 1), None)
 
     def test_registry_get_timedelta(self):
 
@@ -51,7 +51,7 @@ class TestAdapter:
         def add_route_and_views(config):
             config.add_route('dbname', '/test/')
             config.add_view(
-                    get_timedelta, route_name='dbname', renderer='json')
+                get_timedelta, route_name='dbname', renderer='json')
             json_renderer = JSON()
             json_renderer.add_adapter(timedelta, timedelta_adapter)
             config.add_renderer('json', json_renderer)

--- a/anyblok_pyramid/tests/test_adapter.py
+++ b/anyblok_pyramid/tests/test_adapter.py
@@ -55,8 +55,8 @@ class TestAdapter:
                 get_timedelta, route_name='dbname', renderer='json')
             json_renderer = JSON()
             json_renderer.add_adapter(
-                    timedelta, lambda obj, request: timedelta_adapter(
-                        obj, request, mode))
+                timedelta, lambda obj, request: timedelta_adapter(
+                    obj, request, mode))
             config.add_renderer('json', json_renderer)
 
         webserver = init_web_server(add_route_and_views)
@@ -69,25 +69,27 @@ class TestAdapter:
 
         # This part is aimed at testing that the different modes implemented on
         # timedelta adapter are behaving as intented
-        delta = timedelta(weeks=1, days=3, hours=15, minutes=3, seconds=45,
-                milliseconds=354, microseconds=768)
+        delta = timedelta(
+            weeks=1, days=3, hours=15, minutes=3, seconds=45, milliseconds=354,
+            microseconds=768
+        )
 
         assert round(
-                timedelta_adapter(delta, None, 'seconds'), 8)  == 918225.354768
+            timedelta_adapter(delta, None, 'seconds'), 8) == 918225.354768
         assert round(
-                timedelta_adapter(delta, None, 'microseconds'),
-                8) == 918225354768
+            timedelta_adapter(delta, None, 'microseconds'),
+            8) == 918225354768
         assert round(
-                timedelta_adapter(delta, None, 'milliseconds'),
-                8) == 918225354.768
+            timedelta_adapter(delta, None, 'milliseconds'),
+            8) == 918225354.768
         assert round(
-                timedelta_adapter(delta, None, 'minutes'), 8) == 15303.7559128
+            timedelta_adapter(delta, None, 'minutes'), 8) == 15303.7559128
         assert round(
-                timedelta_adapter(delta, None, 'hours'), 8) == 255.06259855
+            timedelta_adapter(delta, None, 'hours'), 8) == 255.06259855
         assert round(
-                timedelta_adapter(delta, None, 'days'), 8) == 10.62760827
+            timedelta_adapter(delta, None, 'days'), 8) == 10.62760827
         assert round(
-                timedelta_adapter(delta, None, 'weeks'), 8) == 1.51822975
+            timedelta_adapter(delta, None, 'weeks'), 8) == 1.51822975
 
         with pytest.raises(ValueError):
             timedelta_adapter(delta, None, "not a valid mode")

--- a/anyblok_pyramid/tests/test_adapter.py
+++ b/anyblok_pyramid/tests/test_adapter.py
@@ -1,6 +1,7 @@
 # This file is a part of the AnyBlok / Pyramid project
 #
 #    Copyright (C) 2015 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#    Copyright (C) 2019 Alexis TOURNEUX <tourneuxalexis@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can

--- a/anyblok_pyramid/tests/test_adapter.py
+++ b/anyblok_pyramid/tests/test_adapter.py
@@ -5,18 +5,19 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from pyramid.renderers import JSON
 from uuid import UUID, uuid1
 from os import urandom
 from decimal import Decimal
 from anyblok_pyramid.adapter import (
-    datetime_adapter,
-    date_adapter,
-    uuid_adapter,
-    bytes_adapter,
-    decimal_adapter,
-)
+        datetime_adapter,
+        date_adapter,
+        timedelta_adapter,
+        uuid_adapter,
+        bytes_adapter,
+        decimal_adapter,
+        )
 from anyblok_pyramid.testing import init_web_server
 
 
@@ -37,7 +38,31 @@ class TestAdapter:
         webserver = init_web_server(add_route_and_views)
         res = webserver.get('/test/', status=200)
         assert res.json_body['datetime'] == datetime_adapter(
-            datetime(2017, 10, 1, 1, 1, 1), None)
+                datetime(2017, 10, 1, 1, 1, 1), None)
+
+    def test_registry_get_timedelta(self):
+
+        def get_timedelta(request):
+            return {'timedelta': timedelta(
+                days=1, hours=4, minutes=56,
+                seconds=3710, milliseconds=4000,
+                microseconds=500)}
+
+        def add_route_and_views(config):
+            config.add_route('dbname', '/test/')
+            config.add_view(
+                    get_timedelta, route_name='dbname', renderer='json')
+            json_renderer = JSON()
+            json_renderer.add_adapter(timedelta, timedelta_adapter)
+            config.add_renderer('json', json_renderer)
+
+        webserver = init_web_server(add_route_and_views)
+        res = webserver.get('/test/', status=200)
+
+        assert res.json_body['timedelta'] == timedelta_adapter(
+            timedelta(
+                days=1, hours=4, minutes=56, seconds=3710,
+                milliseconds=4000, microseconds=500), None)
 
     def test_registry_get_date(self):
 

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -13,6 +13,12 @@
 CHANGELOG
 =========
 
+0.9.6 (Unreleased)
+------------------
+
+* Created a new adapter for timedelta objects. It can parametrized using
+  the new timedelta_adapter_factory and TimedeltaModes enumeration
+
 0.9.5 (2019-11-01)
 ------------------
 


### PR DESCRIPTION
I noticed there was no adapter for datetime.timedelta json rendering object.

I created one using the timedelta.total_seconds method from datetime.timedelta object as a serialization method.